### PR TITLE
New functionality has been added: It is now possible, upon user request opening, that Area, Type, Item and Service come with the SELECT option by default.

### DIFF
--- a/app/lang/en_US.txt
+++ b/app/lang/en_US.txt
@@ -937,6 +937,8 @@ Other_items = "Other Options"
 sys_workdays_request_approval = "Number of days for the system to automatically approve requests closed [0 = never approve]"
 sys_time_session = "Time that will last the session system. Value in seconds. If not set will be 10 minutes."
 
+sys_dont_show_default = "When open request: Do not show area, type, item service default. User chooses regardless of default value."
+
 #--- Grid Sorting -----
 
 grd_show_only_mine = "Show only mine"

--- a/app/lang/pt_BR.txt
+++ b/app/lang/pt_BR.txt
@@ -1016,6 +1016,9 @@ sys_use_equipment = "Utiliza controle de equipamentos [Etiqueta, Serial e OS]"
 Other_items = "Outros Itens"
 sys_workdays_request_approval="N&uacute;mero de dias &uacute;teis para o sistema aprovar automaticamente as solicita&ccedil;&atilde;es encerradas [0 = Nunca aprovar]"
 sys_time_session = "Tempo que ir&aacute; durar a sess&atilde;o do sistema. Valor em segundos. Se n&atilde;o definido ser&aacute; de 10 minutos."
+
+sys_dont_show_default = "Quando abrir solicitação: Não mostrar área, tipo, item service default. Usuário escolhe independente do valor default."
+
 #--- Grid Sorting -----
 
 grd_show_only_mine = "Mostrar as minhas"

--- a/app/modules/helpdezk/controllers/hdkCommonController.php
+++ b/app/modules/helpdezk/controllers/hdkCommonController.php
@@ -132,9 +132,28 @@ class hdkCommon extends Controllers  {
 
         $arrRet['ids'] = $fieldsID;
         $arrRet['values'] = $values;
-        //$arrRet['default'] = $default;
+        $arrRet['default'] = $default;
 
         return $arrRet;
+    }
+
+    public function _comboAreaHtml()
+    {
+
+        $arrArea = $this->_comboArea();
+        $select = '';
+
+        foreach ( $arrArea['ids'] as $indexKey => $indexValue ) {
+            if ($arrArea['default'][$indexKey] == 1) {
+                $default = 'selected="selected"';
+            } else {
+                $default = '';
+            }
+            $select .= "<option value='$indexValue' $default>".$arrArea['values'][$indexKey]."</option>";
+        }
+
+        return $select;
+
     }
 
     public function _getIdCoreDefault($table){
@@ -1170,7 +1189,7 @@ class hdkCommon extends Controllers  {
 
         return $arrRet;
     }
-    
+
     public function _comboSource()
     {
         $rs = $this->dbTicket->selectSource();
@@ -1231,7 +1250,7 @@ class hdkCommon extends Controllers  {
                 }
                 break;
         }
-        
+
 
         $arrRet['ids'] = $fieldsID;
         $arrRet['values'] = $values;
@@ -1240,7 +1259,7 @@ class hdkCommon extends Controllers  {
         return $arrRet;
     }
 
-    public function _abilitiesListHtml($type,$rep) {	
+    public function _abilitiesListHtml($type,$rep) {
         $abilities = "";
 		if ($type == 'group') {
             $ret = $this->dbTicket->getAbilityGroup($rep);
@@ -1251,7 +1270,7 @@ class hdkCommon extends Controllers  {
                     $ret->MoveNext();
                 }
                 $abilities .= "</table>";
-            } 
+            }
         }
 		elseif ($type == 'operator') {
             $ret = $this->dbTicket->getAbilityOperator($rep);
@@ -1267,11 +1286,11 @@ class hdkCommon extends Controllers  {
 		return $abilities;
     }
 
-	public function _groupsListHtml($type,$rep) {  
+	public function _groupsListHtml($type,$rep) {
         $groups = "";
         if ($type == 'group') {
             $ret = $this->dbTicket->getGroupOperators($rep);
-            
+
             if ($ret->fields) {
                 $groups = "<table class='table'>";
                 while (!$ret->EOF) {
@@ -1279,7 +1298,7 @@ class hdkCommon extends Controllers  {
                     $ret->MoveNext();
                 }
                 $groups .= "</table>";
-            } 
+            }
         } elseif ($type == 'operator') {
             $ret = $this->dbTicket->getOperatorGroups($rep);
             if ($ret->fields) {

--- a/app/modules/helpdezk/controllers/hdkTicketController.php
+++ b/app/modules/helpdezk/controllers/hdkTicketController.php
@@ -1746,13 +1746,41 @@ class hdkTicket extends hdkCommon {
         echo $lineNotes;
     }
 
+    public function showDefaults()
+    {
+        if (isset($_SESSION['hdk']['TKT_DONT_SHOW_DEFAULT']) && $_SESSION['hdk']['TKT_DONT_SHOW_DEFAULT'] == 1) {
+            echo 'NO';
+        } else {
+            echo 'YES';
+        }
+    }
+
+
     public function areaDefault()
     {
-        $idArea = $this->_getIdAreaDefault();
-        if ($idArea > 0)
-            echo $this->_comboTypeHtml($idArea);
-        else
+        // Since December 26, 2019
+        if (isset($_SESSION['hdk']['TKT_DONT_SHOW_DEFAULT']) && $_SESSION['hdk']['TKT_DONT_SHOW_DEFAULT'] == 1) {
             echo 'NO';
+        } else {
+            $idArea = $this->_getIdAreaDefault();
+            if ($idArea > 0)
+                //echo $this->_comboTypeHtml($idArea);
+                echo 'YES';
+            else
+                echo 'NO';
+        }
+
+    }
+
+    public function ajaxTypeWithAreaDefault()
+    {
+        $idArea = $this->_getIdAreaDefault();
+        echo $this->_comboTypeHtml($idArea);
+    }
+
+    public function ajaxArea()
+    {
+        echo $this->_comboAreaHtml();
     }
 
     public function ajaxTypes()

--- a/app/modules/helpdezk/views/js/newticket.js
+++ b/app/modules/helpdezk/views/js/newticket.js
@@ -1,20 +1,32 @@
 var global_coderequest = '';
+var htmlArea = '',
+    showDefs  = '';
+
+
 $(document).ready(function () {
 
     countdown.start(timesession);
 
     new gnMenu( document.getElementById( 'gn-menu' ) );
 
-    // Exists Area Default ?
-    $.post(path + "/helpdezk/hdkTicket/areaDefault",
-        function (valor) {
-            if (valor != 'NO') {
+    htmlArea = makeAreaCombo();
+    showDefs = showDefaults();
+
+    console.log('exist: '+ showDefs);
+
+    if (showDefs == 'YES') {
+        $("#areaId").html(htmlArea);
+        $.post(path + "/helpdezk/hdkTicket/ajaxTypeWithAreaDefault",
+            function (valor) {
                 $('#typeId').removeAttr('disabled');
                 $("#typeId").html(valor);
                 $("#typeId").trigger("chosen:updated");
                 return objNewTicket.changeItem();
-            }
-    })
+            })
+    } else if (showDefs == 'NO') {
+        $("#areaId").html('<option value="X">'+makeSmartyLabel('Select')+'</option>' + htmlArea);
+        $("#areaId").val('X');
+    }
 
 
     $('[data-toggle="tooltip"]').tooltip();
@@ -79,14 +91,27 @@ $(document).ready(function () {
         ignore:[],
         rules: {
             subject: "required",  // simple rule, converted to {required:true}
-            area: "required",
-            typeId: "required",
-            itemId: "required",
-            serviceId: "required"
+            areaId: {
+                required: true,
+                number: true
+            },
+            typeId: {
+                required: true,
+                number: true
+            },
+            itemId: {
+                required: true,
+                number: true
+            },
+            serviceId: {
+                required: true,
+                number: true
+            }
+
         },
         messages: {
             subject: makeSmartyLabel('Alert_empty_subject'),
-            area: makeSmartyLabel('Alert_field_required'),
+            areaId: makeSmartyLabel('Alert_field_required'),
             typeId: makeSmartyLabel('Alert_field_required'),
             itemId: makeSmartyLabel('Alert_field_required'),
             serviceId: makeSmartyLabel('Alert_field_required')
@@ -174,10 +199,18 @@ $(document).ready(function () {
             var areaId = $("#areaId").val();
             $.post(path+"/helpdezk/hdkTicket/ajaxTypes",{areaId: areaId},
                 function(valor){
+
                     $('#typeId').removeAttr('disabled');
-                    $("#typeId").html(valor);
-                    $("#typeId").trigger("chosen:updated");
-                    return objNewTicket.changeItem();
+
+                    if (showDefs == 'YES') {
+                        $("#typeId").html(valor);
+                        $("#typeId").trigger("chosen:updated");
+                        return objNewTicket.changeItem();
+                    } else if (showDefs == 'NO') {
+                        $("#typeId").html('<option value="X">'+makeSmartyLabel('Select')+'</option>' + valor);
+                        $("#typeId").val('X');
+                        $("#typeId").trigger("chosen:updated");
+                    }
                 })
         },
         changeItem: function(){
@@ -185,9 +218,15 @@ $(document).ready(function () {
             $.post(path+"/helpdezk/hdkTicket/ajaxItens",{typeId: typeId},
                 function(valor){
                     $('#itemId').removeAttr('disabled');
-                    $("#itemId").html(valor);
-                    $("#itemId").trigger("chosen:updated");
-                    return objNewTicket.changeService();
+                    if (showDefs == 'YES') {
+                        $("#itemId").html(valor);
+                        $("#itemId").trigger("chosen:updated");
+                        return objNewTicket.changeService();
+                    } else if (showDefs == 'NO') {
+                        $("#itemId").html('<option value="X">'+makeSmartyLabel('Select')+'</option>' + valor);
+                        $("#itemId").val('X');
+                        $("#itemId").trigger("chosen:updated");
+                    }
                 })
         },
         changeService: function(){
@@ -196,9 +235,16 @@ $(document).ready(function () {
             $.post(path+"/helpdezk/hdkTicket/ajaxServices",{itemId: itemId},
                 function(valor){
                     $('#serviceId').removeAttr('disabled');
-                    $("#serviceId").html(valor);
-                    $("#serviceId").trigger("chosen:updated");
-                    return objNewTicket.changeReason();
+                    if (showDefs == 'YES') {
+                        $("#serviceId").html(valor);
+                        $("#serviceId").trigger("chosen:updated");
+                        return objNewTicket.changeReason();
+                    } else if (showDefs == 'NO') {
+                        $("#serviceId").html('<option value="X">'+makeSmartyLabel('Select')+'</option>' + valor);
+                        $("#serviceId").val('X');
+                        $("#serviceId").trigger("chosen:updated");
+                    }
+
                 })
         },
         changeReason: function(){
@@ -257,42 +303,35 @@ $(document).ready(function () {
 
 
 });
-/*
 
-function changeType(paramAreaID)
+function makeAreaCombo()
 {
-    console.log('changeType, areaId: '+ paramAreaID);
-    $.post(path+"/helpdezk/hdkTicket/ajaxTypes",{areaId: paramAreaID},
-        function(valor){
-            $('#typeId').removeAttr('disabled');
-            $("#typeId").html(valor);
-    })
-    return changeItem($("#typeId").val());
+    var result="";
+    $.ajax({
+        url: path+"/helpdezk/hdkTicket/ajaxArea" ,
+        type: "POST",
+        async: false,
+        success: function(data) {
+            result = data;
+        }
+    });
+    return result;
 }
 
-function changeItem(paramTypeID)
+function showDefaults()
 {
-    console.log('changeItem, typeId: '+ paramTypeID);
-    console.log($("#newticket-form").find('#typeId').val());
-    console.log($("#typeId option:first").val());
-    $.post(path+"/helpdezk/hdkTicket/ajaxItens",{typeId: paramTypeID},
-        function(valor){
-            $('#itemId').removeAttr('disabled');
-            $("#itemId").html(valor);
-        })
-    return changeService($("#itemId").val());
-}
+    var result="";
+    $.ajax({
+        url: path+"/helpdezk/hdkTicket/showDefaults" ,
+        type: "POST",
+        async: false,
+        success: function(data) {
+            result = data;
+        }
+    });
+    return result;
 
-function changeService(paramItemID)
-{
-    $.post(path+"/helpdezk/hdkTicket/ajaxServices",{itemId: paramItemID},
-        function(valor){
-            $('#serviceId').removeAttr('disabled');
-            $("#serviceId").html(valor);
-        })
-    return false;
 }
-*/
 
 function makeOptLabel(confName)
 {

--- a/app/modules/helpdezk/views/new_ticket.tpl
+++ b/app/modules/helpdezk/views/new_ticket.tpl
@@ -68,17 +68,17 @@
     {head_item type="css" src="$path/css/plugins/chosen/" files="chosen.css"}
     {literal}
     <script type="text/javascript">
-         var     default_lang = "{/literal}{$lang}{literal}",
-                 path = "{/literal}{$path}{literal}",
-                 langName = '{/literal}{$smarty.config.Name}{literal}',
-                 theme = '{/literal}{$theme}{literal}',
-                 mascDateTime = '{/literal}{$mascdatetime}{literal}',
-                 timesession = '{/literal}{$timesession}{literal}',
-                 noteAttMaxFiles = '{/literal}{$noteattmaxfiles}{literal}',
-                 noteAcceptedFiles = '{/literal}{$noteacceptedfiles}{literal}',
-                 ticketAttMaxFiles = '{/literal}{$ticketattmaxfiles}{literal}',
-                 ticketAcceptedFiles = '{/literal}{$ticketacceptedfiles}{literal}',
-                 hdkMaxSize = '{/literal}{$hdkMaxSize}{literal}';
+         var     default_lang           = "{/literal}{$lang}{literal}",
+                 path                   = "{/literal}{$path}{literal}",
+                 langName               = '{/literal}{$smarty.config.Name}{literal}',
+                 theme                  = '{/literal}{$theme}{literal}',
+                 mascDateTime           = '{/literal}{$mascdatetime}{literal}',
+                 timesession            = '{/literal}{$timesession}{literal}',
+                 noteAttMaxFiles        = '{/literal}{$noteattmaxfiles}{literal}',
+                 noteAcceptedFiles      = '{/literal}{$noteacceptedfiles}{literal}',
+                 ticketAttMaxFiles      = '{/literal}{$ticketattmaxfiles}{literal}',
+                 ticketAcceptedFiles    = '{/literal}{$ticketacceptedfiles}{literal}',
+                 hdkMaxSize             = '{/literal}{$hdkMaxSize}{literal}';
 
 
     </script>
@@ -206,9 +206,10 @@
                         <div class="form-group"><label class="col-sm-3 control-label">{$smarty.config.Area}: </label>
                             {*<div class="col-sm-10"><input type="text" class="form-control input-sm"></div>*}
                             <div class="col-sm-9">
-                                <select class="form-control  form-control-sm" name="area" id="areaId" >
+                                <select class="form-control  form-control-sm" name="areaId" id="areaId" >
                                     <option value="">{$smarty.config.Select} </option>
-                                    {html_options values=$areaids output=$areavals selected=$idarea}
+                                    {* {html_options values=$areaids output=$areavals selected=$idarea}*}
+
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
New functionality has been added: It is now possible, upon user request opening, that Area, Type, Item and Service come with the SELECT option by default. Forcing the user to choose the value of each of the combos.
This feature was requested because some users did not correctly define the requested Area / Type / Item / Service.
This feature can be enabled.
Admin -> Config -> System Features -> Helpdezk: "When opening request: Do not show area, type, default service item. User chooses regardless of default value."